### PR TITLE
feat: Add support for users to bring their own Redis with connection pool

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
   specs:
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
+    connection_pool (2.4.1)
     dalli (2.7.9)
     diff-lcs (1.3)
     docile (1.3.1)
@@ -20,7 +21,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rake (13.0.1)
-    redis (4.0.3)
+    redis (4.8.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -45,11 +46,12 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.16)
+  connection_pool (~> 2.2)
   dalli
   prefatory!
   pry
   rake (~> 13.0)
-  redis
+  redis (~> 4.3)
   rspec (~> 3.0)
   simplecov
 

--- a/lib/prefatory/config.rb
+++ b/lib/prefatory/config.rb
@@ -16,6 +16,7 @@ module Prefatory
     setting :primary_uuid, :primary_uuid
   end
   setting :storage do
+    setting :redis_client
     setting :provider # :memcached or :redis
     setting :options
     setting :marshaler, Marshal

--- a/prefatory.gemspec
+++ b/prefatory.gemspec
@@ -25,7 +25,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.add_dependency "dry-configurable", "~> 0.7.0"
 
-  spec.add_development_dependency "redis"
+  spec.add_development_dependency "redis", "~> 4.3"
+  spec.add_development_dependency "connection_pool", "~> 2.2"
   spec.add_development_dependency "dalli"
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "pry"

--- a/spec/prefatory/storage/redis_provider_spec.rb
+++ b/spec/prefatory/storage/redis_provider_spec.rb
@@ -1,10 +1,19 @@
 require 'prefatory/storage/redis_provider'
+require 'connection_pool'
 require_relative '../prefatory_shared'
 
 RSpec.describe Prefatory::Storage::RedisProvider do
 
-  let(:storage) {Prefatory::Storage::RedisProvider.new}
-  let(:repo) {Prefatory::Repository.new(storage: storage)}
-  include_examples 'prefatory_repository'
-end
+  context 'when passing a connection pool object' do
+    let(:repo) {Prefatory::Repository.new(storage: storage)}
+    let(:redis_pool) {ConnectionPool.new(size: 5, timeout: 5) { Redis.new}}
+    let(:storage) {Prefatory::Storage::RedisProvider.new(redis_client: redis_pool)}
+    include_examples 'prefatory_repository'
+  end
 
+  context 'when using a redis connection' do
+    let(:repo) {Prefatory::Repository.new(storage: storage)}
+    let(:storage) {Prefatory::Storage::RedisProvider.new}
+    include_examples 'prefatory_repository'
+  end
+end


### PR DESCRIPTION
* It is now possible for users to pass a Redis client, which could be a Redis instance or a Connection Pool object.
* We are now using exists? instead of exists, however, this is a breaking change for Redis and now requires Redis to be minimum 4.3+. I'm not adding any specific logic that would check against that but this gem will break if attempting to use it with Redis below 4.2 as per https://github.com/redis/redis-rb/blob/da958451249723ade0b5d4b72e3cfbfcebcd7061/CHANGELOG.md#420.
